### PR TITLE
feat: ai assisted development

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -7,6 +7,7 @@ This directory contains guidance for AI-assisted development in Navigator. The d
 - `navigator-solution`: use for solution layout, project creation, project references, and validation workflow.
 - `navigator-architecture`: use for core framework behavior, request lifecycle, dependency injection, strategies, pipelines, argument resolution, and tracing.
 - `navigator-extension-authoring`: use for `Navigator.Extensions.*` packages, extension options, extension pipeline steps, builder APIs, tests, samples, packaging, and README updates.
+- `navigator-execplan`: use when planning a feature or substantial change with an ExecPlan governed by `.agents/PLANS.md`.
 
 ## Documentation Map
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,29 @@
+# Agent Guide
+
+This directory contains guidance for AI-assisted development in Navigator. The documentation in `docs/` is the source of truth; skills are short task-specific workflows that point agents to the right files.
+
+## Skills
+
+- `navigator-solution`: use for solution layout, project creation, project references, and validation workflow.
+- `navigator-architecture`: use for core framework behavior, request lifecycle, dependency injection, strategies, pipelines, argument resolution, and tracing.
+- `navigator-extension-authoring`: use for `Navigator.Extensions.*` packages, extension options, extension pipeline steps, builder APIs, tests, samples, packaging, and README updates.
+
+## Documentation Map
+
+- `docs/ARCHITECTURE.md`: runtime architecture and internal flow.
+- `docs/EXTENSION-AUTHORING.md`: how to create and maintain extension packages.
+- `.agents/PLANS.md`: requirements for long-running executable plans.
+
+## Default Agent Workflow
+
+1. Read the relevant skill.
+2. Read the documentation linked by that skill.
+3. Inspect the nearest existing implementation before editing.
+4. Keep README examples aligned with user-facing API or behavior changes.
+5. Run strict validation from `src/` before finishing:
+
+```bash
+dotnet restore
+dotnet build -c Release --no-restore
+dotnet test -c Release --no-build --verbosity normal
+```

--- a/.agents/skills/navigator-architecture/SKILL.md
+++ b/.agents/skills/navigator-architecture/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: navigator-architecture
+description: Use when working on Navigator core behavior, request processing, dependency injection, action resolution, execution pipelines, argument resolution, tracing, webhook handling, or any change that needs understanding of the framework runtime architecture.
+---
+
+# Navigator Architecture
+
+Use this skill before changing core runtime behavior or when an issue may involve more than one layer of Navigator's request lifecycle.
+
+## Required Reading
+
+Read `docs/ARCHITECTURE.md` first. It is the source of truth for how webhook updates move through the framework, where services are registered, how strategies use the resolution and execution pipelines, how handler arguments are resolved, and where tracing fits.
+
+If the task involves extension packages, also use `navigator-extension-authoring` and read `docs/EXTENSION-AUTHORING.md`.
+
+## Workflow
+
+1. Identify the layer being changed:
+   - webhook endpoint and startup: `src/Navigator/Configuration/`
+   - dependency injection: `src/Navigator/ServiceCollectionExtensions.cs`
+   - strategy orchestration: `src/Navigator/Strategy/`
+   - action catalog and builders: `src/Navigator/Catalog/`, `src/Navigator/Actions/`
+   - classification: `src/Navigator/Classifier/`
+   - pipeline composition and steps: `src/Navigator/Pipelines/`
+   - public contracts: `src/Navigator.Abstractions/`
+   - tracing: `src/Navigator/Introspection/` and `src/Navigator.Abstractions/Introspection/`
+2. Inspect the nearest existing implementation before editing.
+3. Preserve public abstractions unless the requested change truly requires a contract change.
+4. Update README examples when user-facing behavior, configuration, or public APIs change.
+5. Add or update focused tests in `src/Navigator.Testing`.
+6. Validate strictly from `src/`:
+
+```bash
+dotnet restore
+dotnet build -c Release --no-restore
+dotnet test -c Release --no-build --verbosity normal
+```
+
+## Guardrails
+
+- Do not bypass `INavigatorStrategy` for update processing.
+- Do not register services in samples to compensate for missing framework registrations.
+- Do not make pipeline ordering implicit in registration order when priority or before/main/after step interfaces are the intended mechanism.
+- Do not silently change exception behavior in the execution pipeline; document and test any deliberate change.
+- Do not edit `src/Navigator.sln` manually for project operations when `dotnet sln` can do it.

--- a/.agents/skills/navigator-execplan/SKILL.md
+++ b/.agents/skills/navigator-execplan/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: navigator-execplan
+description: Use when the user asks to plan a Navigator feature, write an implementation plan, create or update an ExecPlan, break down a substantial change into milestones, or prepare a self-contained specification before coding.
+---
+
+# Navigator ExecPlan
+
+Use this skill when the user asks for a plan for a feature or substantial repository change.
+
+## Required Reading
+
+Read `.agents/PLANS.md` before writing, updating, or implementing an ExecPlan. That file is the source of truth for the required structure, tone, self-contained context, progress tracking, validation, and living-document rules.
+
+If the plan involves core runtime behavior, also use `navigator-architecture` and read `docs/ARCHITECTURE.md`.
+
+If the plan involves `Navigator.Extensions.*`, also use `navigator-extension-authoring` and read `docs/EXTENSION-AUTHORING.md`.
+
+If the plan involves project or solution layout, also use `navigator-solution`.
+
+## Workflow
+
+1. Clarify scope when needed. Ask concise questions if the expected behavior, public API, package target, or validation outcome is ambiguous.
+2. Read the relevant source files before planning. Do not write a generic plan detached from the current code.
+3. Produce a self-contained ExecPlan that a novice could follow with only the repository and the plan file.
+4. Include user-visible purpose, exact files, concrete steps, validation commands, acceptance behavior, idempotence, and recovery notes.
+5. Maintain the required living sections:
+   - `Progress`
+   - `Surprises & Discoveries`
+   - `Decision Log`
+   - `Outcomes & Retrospective`
+6. If the user asks only for a plan, do not start implementation unless they explicitly ask to proceed.
+
+## Formatting Rules
+
+- Follow `.agents/PLANS.md` exactly.
+- When returning an ExecPlan directly in chat, wrap the whole plan in one fenced `md` code block.
+- When writing an ExecPlan to a Markdown file that contains only the plan, omit the outer fence.
+- Do not nest triple-backtick fences inside an ExecPlan.
+- Prefer prose-first milestones with checkboxes only in `Progress`.
+
+## Validation Policy
+
+Plans for code changes should end with strict validation from `src/` unless there is a documented reason not to:
+
+```bash
+dotnet restore
+dotnet build -c Release --no-restore
+dotnet test -c Release --no-build --verbosity normal
+```
+
+For documentation-only plans, specify a concrete review or consistency check instead of pretending a build proves the doc change.

--- a/.agents/skills/navigator-extension-authoring/SKILL.md
+++ b/.agents/skills/navigator-extension-authoring/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: navigator-extension-authoring
+description: Use when creating, modifying, testing, packaging, or documenting Navigator.Extensions.* packages, extension options, extension services, pipeline steps, action builder methods, extension samples, or extension-specific README examples.
+---
+
+# Navigator Extension Authoring
+
+Use this skill for work in `src/Navigator.Extensions.*` or for core changes made to support extension packages.
+
+## Required Reading
+
+Read `docs/EXTENSION-AUTHORING.md` before editing. It defines the expected package shape, extension registration contracts, options patterns, pipeline step placement, tests, samples, README updates, packaging expectations, and strict validation commands.
+
+Read `docs/ARCHITECTURE.md` as well when the extension changes action resolution, action execution, argument resolution, tracing, or dependency injection contracts.
+
+## Workflow
+
+1. Classify the extension work:
+   - no configuration: implement `INavigatorExtension`
+   - user configuration: implement `INavigatorExtension<TOptions>` with an options type implementing `INavigatorExtensionOptions`
+   - action behavior: add builder extension methods that store options on `BotActionInformation`
+   - update filtering or processing: add a resolution or execution pipeline step
+   - external state: register the required services and document lifetimes
+2. Match a nearby package:
+   - simple pipeline extension: `src/Navigator.Extensions.Cooldown/`
+   - action filtering extension: `src/Navigator.Extensions.Probabilities/`
+   - EF Core and custom options: `src/Navigator.Extensions.Store/`
+   - command-style management extension: `src/Navigator.Extensions.Management/`
+3. Update or add tests in `src/Navigator.Testing` for the extension's observable behavior.
+4. Update README examples when the extension's public API or behavior changes.
+5. Add or update a sample under `src/samples/` when the extension introduces a major user workflow.
+6. Validate strictly from `src/`:
+
+```bash
+dotnet restore
+dotnet build -c Release --no-restore
+dotnet test -c Release --no-build --verbosity normal
+```
+
+## Guardrails
+
+- Treat extension packages as independently publishable NuGet packages unless the user says otherwise.
+- Keep extension-specific implementation inside the extension project; put only reusable contracts in `Navigator.Abstractions`.
+- Do not add package-only behavior that cannot be demonstrated by tests or a sample.
+- Do not require users to register internal extension services manually after calling `WithExtension`.
+- Do not introduce user-visible API changes without updating README usage.

--- a/.agents/skills/navigator-solution/SKILL.md
+++ b/.agents/skills/navigator-solution/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: navigator-solution
+description: Use when working inside the Navigator repository to create, modify, or validate .NET projects, solution structure, tests, samples, extensions, or strategies. This skill defines the required `dotnet` CLI workflow, naming conventions, project placement, and validation commands for this solution.
+---
+
+# Navigator Solution
+
+This skill applies to work inside the `Navigator` repository and assumes the solution root contains `src/Navigator.sln`.
+
+## Working Rules
+
+- Use the `dotnet` CLI for project and solution operations. Do not hand-edit `.sln` files or create projects through IDE-only flows when `dotnet` provides the command.
+- Run solution-level commands from `src/`, where `Navigator.sln` and `global.json` live.
+- Respect `global.json`. The repository is pinned to `.NET SDK 10.0.0`, and existing projects target `net10.0`.
+- Keep changes aligned with the current solution layout and naming patterns instead of inventing a new structure.
+
+## Repository Shape
+
+The solution is organized under `src/`:
+
+- `Navigator/` and `Navigator.Abstractions/` contain the core libraries.
+- `Navigator.Extensions.*` contains extension packages.
+- `Navigator.Strategies.*` contains strategy packages.
+- `Navigator.Testing/` contains the test project.
+- `samples/` contains runnable sample applications.
+
+When adding new code, place it according to that structure:
+
+- New packable framework libraries belong beside the existing top-level projects in `src/`.
+- New extension packages should follow `Navigator.Extensions.<Name>`.
+- New strategy packages should follow `Navigator.Strategies.<Name>`.
+- New samples should live under `src/samples/<SampleName>/`.
+- Prefer extending `Navigator.Testing` for tests unless a separate test project is clearly justified.
+
+## Required CLI Workflow
+
+For new projects, always start with the `dotnet` CLI.
+
+Common commands:
+
+```bash
+cd src
+dotnet new classlib -n Navigator.Extensions.Example
+dotnet new xunit -n Navigator.FeatureName.Tests
+dotnet new web -n SampleWithExample -o samples/SampleWithExample
+dotnet sln Navigator.sln add Navigator.Extensions.Example/Navigator.Extensions.Example.csproj
+dotnet sln Navigator.sln add samples/SampleWithExample/SampleWithExample.csproj
+dotnet add samples/SampleWithExample/SampleWithExample.csproj reference Navigator/Navigator.csproj
+```
+
+Use CLI commands for these operations:
+
+- project creation: `dotnet new`
+- solution membership: `dotnet sln add`
+- project references: `dotnet add <project> reference <project>`
+- package references: `dotnet add <project> package <package>`
+
+Only edit project files manually when the CLI cannot express the needed metadata cleanly.
+
+## Project Conventions
+
+Match the conventions already used in this repository:
+
+- Target `net10.0`.
+- Enable nullable reference types.
+- Use implicit usings where the surrounding project style already does.
+- Packable libraries usually include package metadata and XML documentation generation.
+- Sample applications are not packable.
+- Test projects should stay non-packable and use the existing xUnit-based stack unless there is a concrete reason to change it.
+
+Before adding a new project, inspect a nearby existing project of the same kind:
+
+- core library: `src/Navigator/Navigator.csproj`
+- extension library: `src/Navigator.Extensions.Store/Navigator.Extensions.Store.csproj`
+- strategy library: `src/Navigator.Strategies.Queued/Navigator.Strategies.Queued.csproj`
+- test project: `src/Navigator.Testing/Navigator.Testing.csproj`
+- sample app: `src/samples/Sample/Sample.csproj`
+
+## Validation
+
+Prefer the same validation flow used by CI. Run from `src/`:
+
+```bash
+dotnet restore
+dotnet build -c Release --no-restore
+dotnet test -c Release --no-build --verbosity normal
+```
+
+If the change is scoped to one project, a narrower build or test command is acceptable while iterating, but finish with the broadest validation that is practical for the touched area.
+
+## Guardrails
+
+- Do not move projects out of `src/` or create parallel solution layouts.
+- Do not introduce Visual Studio-specific setup steps when an equivalent `dotnet` workflow exists.
+- Do not add a new sample, extension, or strategy with inconsistent naming.
+- Do not manually patch the solution file for routine add/remove operations that `dotnet sln` can perform safely.
+
+## Default Approach
+
+When asked to add a new capability to this repository:
+
+1. Identify whether it belongs in a core library, extension, strategy, sample, or test.
+2. Create any new project with `dotnet new`.
+3. Add it to `src/Navigator.sln` with `dotnet sln add`.
+4. Add references with `dotnet add reference`.
+5. Match the nearest existing project’s `.csproj` conventions.
+6. Validate with `dotnet restore`, `dotnet build`, and `dotnet test` from `src/`.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.userprefs
 
 appsettings.Local.json
+.agents/plans/
 
 # Build results
 [Dd]ebug/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,157 @@
+# Navigator Architecture
+
+This document explains how Navigator processes Telegram updates and where contributors should make changes. It is written for human contributors and AI agents.
+
+## Repository Orientation
+
+Navigator is a .NET Telegram bot framework. The solution lives under `src/` and is pinned by `src/global.json`. The main projects are:
+
+- `src/Navigator.Abstractions/`: public contracts shared by the framework, extensions, strategies, and user code.
+- `src/Navigator/`: core runtime, dependency injection, action builders, catalog, classifiers, pipelines, strategies, tracing, and webhook mapping.
+- `src/Navigator.Extensions.*`: optional extension packages.
+- `src/Navigator.Strategies.*`: optional strategy packages that replace update processing behavior.
+- `src/Navigator.Testing/`: xUnit tests for core and package behavior.
+- `src/samples/`: runnable examples for user-facing workflows.
+
+Use `docs/EXTENSION-AUTHORING.md` for extension-specific work.
+
+## Startup And Service Registration
+
+Applications register Navigator with `AddNavigator` from `src/Navigator/ServiceCollectionExtensions.cs`. That method:
+
+1. Builds a `NavigatorConfiguration` from the user callback.
+2. Registers core services such as `INavigatorClient`, `BotActionCatalogFactory`, `IUpdateClassifier`, argument resolvers, tracing, and pipeline builders.
+3. Registers default pipeline steps based on `NavigatorOptions`.
+4. Registers `DefaultNavigationStrategy`.
+5. Runs configured strategies and extensions through `NavigatorConfiguration.Configure`.
+6. Registers `INavigatorStrategy` as the default strategy if no custom strategy was configured.
+7. Imports configured options into `IOptions<NavigatorOptions>`.
+
+`NavigatorConfiguration` in `src/Navigator/Configuration/NavigatorConfiguration.cs` stores requested extensions and the optional strategy. `WithExtension<T>()` appends extension definitions. `WithStrategy<T>()` replaces the active strategy because only one strategy can process updates.
+
+## Webhook Entry Point
+
+`MapNavigator()` in `src/Navigator/Configuration/EndpointRouteBuilderExtensions.cs` maps a POST endpoint using `NavigatorOptions.GetWebHookEndpointOrDefault()`. The endpoint receives a Telegram `Update`, takes the current `HttpContext.TraceIdentifier` as the update identifier, and calls `INavigatorStrategy.Invoke(update, identifier)`.
+
+The endpoint logs unhandled exceptions. The default execution pipeline catches handler exceptions inside action execution, so not every action failure reaches the endpoint.
+
+## Strategy Layer
+
+A strategy decides how an incoming update is processed.
+
+The default strategy is `src/Navigator/Strategy/DefaultNavigationStrategy.cs`. It processes one update immediately:
+
+1. Starts a trace and adds update tags such as update id, chat id, message id, user id, and update type.
+2. Builds a `NavigatorUpdateContext`.
+3. Builds and invokes the resolution pipeline.
+4. Converts resolved actions into execution contexts.
+5. Builds and invokes the execution pipeline for each action.
+
+Custom strategy packages live under `src/Navigator.Strategies.*`. For example, `Navigator.Strategies.Queued` enqueues updates by a Telegram-derived key, and a hosted worker later runs the normal processing flow.
+
+Do not bypass `INavigatorStrategy` for update processing. If behavior changes how updates are scheduled, ordered, retried, or partitioned, it probably belongs in a strategy package. If behavior changes which actions match or how they execute, it probably belongs in pipeline steps or core action code.
+
+## Action Registration And Catalog
+
+User code calls `app.GetBot()` to retrieve the action catalog and registers actions with helpers such as `OnCommand`, `OnMessage`, and `OnCallbackQuery`.
+
+The relevant code is in:
+
+- `src/Navigator/Catalog/`
+- `src/Navigator/Catalog/Factory/`
+- `src/Navigator/Actions/Builder/`
+- `src/Navigator/Actions/Builder/Extensions/`
+- `src/Navigator.Abstractions/Actions/`
+
+Action builders store metadata in `BotActionInformation`, including category, priority, exclusivity level, chat action, condition input types, handler input types, and extension-specific options. The catalog later retrieves actions by `UpdateCategory`.
+
+When changing public registration helpers, update README examples and add tests that prove the action is classified, resolved, and invoked as expected.
+
+## Classification
+
+`IUpdateClassifier` classifies a Telegram `Update` into an `UpdateCategory`. The default implementation is in `src/Navigator/Classifier/UpdateClassifier.cs`.
+
+The resolution pipeline uses the category to retrieve relevant actions from the catalog. If a new Telegram update type or subkind is supported, update the classifier, action registration helpers, tests, and README or sample docs as needed.
+
+## Pipelines
+
+Navigator has two pipelines:
+
+- Resolution pipeline: selects and filters candidate actions for an update.
+- Execution pipeline: invokes one selected action and cross-cutting behavior around it.
+
+Pipeline builders live in `src/Navigator/Pipelines/Builder/`. Steps live in `src/Navigator/Pipelines/Steps/` or extension packages.
+
+Steps are selected by marker interfaces from `src/Navigator.Abstractions/Pipelines/Steps/`:
+
+- `IActionResolutionPipelineStepBefore`
+- `IActionResolutionMainStep`
+- `IActionResolutionPipelineStepAfter`
+- `IActionExecutionPipelineStepBefore`
+- `IActionExecutionMainStep`
+- `IActionExecutionPipelineStepAfter`
+
+`DefaultActionResolutionMainStep` classifies the update and loads relevant actions into `NavigatorActionResolutionContext.Actions`.
+
+`DefaultActionExecutionMainStep` resolves handler arguments and invokes the action handler. It logs and traces handler exceptions, then continues the pipeline.
+
+Use before or after step interfaces to place extension behavior around the main step. Use the priority attributes already present in the codebase when relative ordering matters.
+
+## Multiple Actions And Exclusivity
+
+Navigator can execute at most one action by default. When `EnableMultipleActionsUsage()` is enabled, resolution uses `FilterExclusiveActionsPipelineStep` instead of `FilterByMultipleActionsPipelineStep`.
+
+Exclusivity is action metadata:
+
+- `None`: the action does not exclude other actions.
+- `Category`: only the highest-priority exclusive action in the same category remains.
+- `Global`: if the highest-priority action is global, all other actions are removed.
+
+Tests for this behavior are in `src/Navigator.Testing/Pipelines/Steps/FilterExclusiveActionsPipelineStepTests.cs`.
+
+## Argument Resolution
+
+Handlers and conditions can declare parameters. `ActionArgumentProvider` in `src/Navigator/Actions/Arguments/ActionArgumentProvider.cs` resolves each requested type.
+
+Resolution order is:
+
+1. Registered `IArgumentResolver` implementations.
+2. The scoped dependency injection container.
+
+Built-in resolvers live in `src/Navigator/Actions/Arguments/Resolvers/`. Extension packages can add resolvers when they introduce injectable domain objects, such as Store entities.
+
+When adding a resolver, test both supported and unsupported parameter types. A resolver should return `null` when it cannot handle a type so later resolvers or DI can try.
+
+## Tracing And Introspection
+
+Tracing contracts live in `src/Navigator.Abstractions/Introspection/`. The default implementation lives in `src/Navigator/Introspection/`.
+
+Core strategies and pipeline steps use `INavigatorTracerFactory<T>` to add tags and record errors. The default sink is `MemoryCacheNavigatorTracerSink`, registered as both `INavigatorTracerSink` and `INavigatorTraceReader`.
+
+When adding meaningful runtime behavior, prefer adding trace tags near the behavior rather than exposing internal state through public APIs.
+
+## Core Change Checklist
+
+For core changes:
+
+1. Identify the layer first: configuration, strategy, catalog, classifier, resolution, execution, argument resolution, or tracing.
+2. Inspect the nearest existing implementation and tests before editing.
+3. Keep public abstractions stable unless the feature needs a contract change.
+4. Update README examples when public APIs or user-visible behavior change.
+5. Add or update focused tests in `src/Navigator.Testing`.
+6. Run strict validation from `src/`.
+
+```bash
+dotnet restore
+dotnet build -c Release --no-restore
+dotnet test -c Release --no-build --verbosity normal
+```
+
+## Common Mistakes To Avoid
+
+- Registering services only in samples when they are required by framework behavior.
+- Adding extension behavior directly to core when it can live in an extension package.
+- Changing pipeline behavior without testing ordering and interaction with multiple actions.
+- Returning a non-null argument from an argument resolver for a type it does not own.
+- Updating public APIs without README examples.
+- Assuming all package projects are implementation details. Extension and strategy projects are usually independently publishable NuGet packages.

--- a/docs/EXTENSION-AUTHORING.md
+++ b/docs/EXTENSION-AUTHORING.md
@@ -1,0 +1,195 @@
+# Navigator Extension Authoring
+
+This document explains how to create and maintain `Navigator.Extensions.*` packages. It is written for human contributors and AI agents.
+
+## When To Build An Extension
+
+Use an extension package for optional behavior that users opt into with `configuration.WithExtension<TExtension>()`. Good extension candidates include action filters, action metadata, additional handler argument sources, persistence, diagnostics, management commands, or integration with another library.
+
+Use core changes instead when the behavior is required for every Navigator app, changes fundamental request processing, or introduces a public abstraction that multiple packages need.
+
+## Existing Extension Models
+
+Use the closest package as a template:
+
+- `src/Navigator.Extensions.Cooldown/`: simple extension with action metadata and resolution/execution pipeline steps.
+- `src/Navigator.Extensions.Probabilities/`: action filtering based on per-action options.
+- `src/Navigator.Extensions.Store/`: EF Core persistence, custom options, services, and argument resolvers.
+- `src/Navigator.Extensions.Management/`: command-style management features and formatter services.
+
+Extension packages are usually independent NuGet packages. Match package metadata and README packaging conventions from nearby extension `.csproj` files.
+
+## Project Shape
+
+Extension projects live under `src/Navigator.Extensions.<Name>/` and are added to `src/Navigator.sln`.
+
+Use `dotnet` commands from `src/` for project and solution operations:
+
+```bash
+dotnet new classlib -n Navigator.Extensions.Example
+dotnet sln Navigator.sln add Navigator.Extensions.Example/Navigator.Extensions.Example.csproj
+dotnet add Navigator.Extensions.Example/Navigator.Extensions.Example.csproj reference Navigator.Abstractions/Navigator.Abstractions.csproj
+```
+
+Most extension projects should:
+
+- target `net10.0`
+- enable nullable reference types
+- generate XML documentation
+- include package metadata
+- include `../../README.md` as `PackageReadmeFile`
+- reference `Navigator.Abstractions`
+
+Only reference `Navigator` when the extension truly needs core implementation types. Prefer abstractions for package boundaries.
+
+## Extension Registration Contracts
+
+Use `INavigatorExtension` when the extension has no user-provided options:
+
+```csharp
+public class ExampleExtension : INavigatorExtension
+{
+    public void Configure(IServiceCollection services, NavigatorOptions options)
+    {
+        services.AddScoped<INavigatorPipelineStep, ExampleStep>();
+    }
+}
+```
+
+Use `INavigatorExtension<TOptions>` when users configure extension options:
+
+```csharp
+public class ExampleExtension : INavigatorExtension<ExampleOptions>
+{
+    public void Configure(IServiceCollection services, NavigatorOptions navigatorOptions, ExampleOptions extensionOptions)
+    {
+        services.AddSingleton(extensionOptions);
+        services.AddScoped<INavigatorPipelineStep, ExampleStep>();
+    }
+}
+```
+
+Options types implement `INavigatorExtensionOptions`. If action builders need to read extension options later, store them through `NavigatorOptions.SetExtensionOptions<TExtension, TOptions>()`, which `NavigatorConfiguration.WithExtension<TExtension, TOptions>()` already does.
+
+Users should not need to manually register internal extension services after calling `WithExtension`.
+
+## Action Metadata And Builder Methods
+
+Extensions often add fluent methods to `IBotActionBuilder`, such as `.WithCooldown(...)`. These methods should store extension-specific metadata on the action builder or final `BotActionInformation`.
+
+Keep builder APIs small and explicit. If a method changes user-facing behavior, update README examples and add tests that prove the metadata affects action resolution or execution.
+
+Prefer extension-specific option keys that are stable and namespaced. Avoid string keys that could collide with core builder keys or other extensions.
+
+## Pipeline Steps
+
+Use a resolution step when the extension decides which actions remain candidates. Examples include cooldown and probability filtering.
+
+Use an execution step when the extension runs behavior around a selected action. Examples include setting cooldown state after an action runs or sending a management response.
+
+Choose the correct marker interface:
+
+- `IActionResolutionPipelineStepBefore`: before actions are classified and loaded.
+- `IActionResolutionPipelineStepAfter`: after actions are loaded.
+- `IActionExecutionPipelineStepBefore`: before the handler runs.
+- `IActionExecutionPipelineStepAfter`: after the handler runs.
+
+Most filtering extensions should run after the main resolution step, because they need `NavigatorActionResolutionContext.Actions` to be populated.
+
+Call `await next()` unless the extension intentionally short-circuits the pipeline. Any short-circuit must be documented and tested.
+
+## Services And Lifetimes
+
+Use lifetimes that match the state being managed:
+
+- `Scoped`: per update or per request behavior.
+- `Singleton`: stateless services, immutable configuration, or shared state designed for concurrency.
+- `HostedService`: background processing owned by the package.
+
+Be careful with singleton pipeline steps that hold mutable state. If shared state is needed, make concurrency behavior explicit and tested.
+
+## Argument Resolvers
+
+Extensions can register `IArgumentResolver` implementations to make new handler parameter types available.
+
+Resolvers should:
+
+- return a value only for types they own
+- return `null` for unsupported types
+- avoid throwing for ordinary unsupported update shapes
+- use scoped services when resolving request-specific data
+
+Store is the main model for this pattern.
+
+## Samples And README Updates
+
+Update README examples whenever the extension changes public API, configuration, package behavior, or user-facing semantics.
+
+Add or update a sample under `src/samples/` when a feature needs more than a short README snippet to understand. Extension samples should show the complete application setup, including `AddNavigator`, `WithExtension`, relevant appsettings, action registration, and `MapNavigator`.
+
+Do not put secrets in samples. Use configuration placeholders such as `TELEGRAM_TOKEN` and `BASE_WEBHOOK_URL`.
+
+## Testing
+
+Add or update tests in `src/Navigator.Testing`. Keep tests focused on observable behavior:
+
+- extension registration adds the expected services or pipeline steps
+- builder methods store the expected metadata
+- resolution steps keep or remove the correct actions
+- execution steps run before or after handlers as intended
+- argument resolvers return expected values and defer unsupported types
+- options are honored
+
+Follow existing test style: xUnit, FluentAssertions, and NSubstitute.
+
+## Packaging
+
+Extension packages are usually publishable NuGet packages. Match nearby `.csproj` metadata:
+
+- `Title`
+- `Authors`
+- `Description`
+- `PackageProjectUrl`
+- `RepositoryUrl`
+- `PackageIconUrl`
+- `PackageReadmeFile`
+- `PackageTags`
+- `PackageRequireLicenseAcceptance`
+- `PackageLicenseExpression`
+- `Copyright`
+
+If an extension introduces a package dependency, keep it in the extension package unless core or abstractions require it.
+
+## Strict Validation
+
+Run strict validation from `src/` before finishing extension work:
+
+```bash
+dotnet restore
+dotnet build -c Release --no-restore
+dotnet test -c Release --no-build --verbosity normal
+```
+
+Scoped commands are acceptable while iterating, but final validation should use the full sequence above.
+
+## Extension Change Checklist
+
+1. Confirm the behavior belongs in an extension.
+2. Inspect the closest existing extension package.
+3. Keep package boundaries clean and prefer `Navigator.Abstractions`.
+4. Register all required services inside the extension.
+5. Add builder methods, options, pipeline steps, resolvers, or services only as needed.
+6. Update README examples for public behavior.
+7. Add or update a sample for larger workflows.
+8. Add or update tests.
+9. Run strict validation.
+
+## Common Mistakes To Avoid
+
+- Making users register services manually after `WithExtension`.
+- Adding extension-specific behavior directly to core.
+- Adding package dependencies to `Navigator` when only one extension needs them.
+- Forgetting README examples after changing fluent APIs.
+- Writing a pipeline step that depends on action metadata but runs before actions are loaded.
+- Returning unsupported argument types from a resolver instead of `null`.
+- Treating extension packages as internal projects when they are usually shipped independently.


### PR DESCRIPTION
## Summary
What changed?

- Added an `.agents/` guide for AI-assisted development in Navigator.
- Added task-specific agent skills for solution work, architecture changes, extension authoring, and ExecPlan creation.
- Added `docs/ARCHITECTURE.md` to document Navigator runtime flow, service registration, strategies, action resolution/execution, argument resolution, and tracing.
- Added `docs/EXTENSION-AUTHORING.md` to document extension package structure, registration contracts, pipeline steps, services, testing, samples, and packaging expectations.
- Ignored `.agents/plans/` so local planning files are not committed.

## Why
Why is this change needed?

This gives contributors and AI agents a consistent source of truth for how to work in the Navigator repository. The new docs make framework architecture and extension authoring conventions explicit, while the agent skills point task-specific workflows at the right documentation and validation commands.

## Notes
Anything reviewers should pay attention to?

Docs-only change. Build and test were not run because no source or project files changed. Reviewers should focus on whether the architecture and extension-authoring guidance accurately reflects the current repository conventions.